### PR TITLE
Adding artifact type and name in usage along with calling help if no …

### DIFF
--- a/cmd/supermarket.go
+++ b/cmd/supermarket.go
@@ -16,10 +16,15 @@ var superMarketUri, enableSupermarket, configPath string
 
 // SupermarketCmd represents the supermarket command
 var SupermarketCmd = &cobra.Command{
-	Use:   "supermarket",
-	Short: "chef supermarket subcommand is used to interact with cookbooks that are located in on the public Supermarket",
-	Long:  `The chef supermarket subcommand is used to interact with cookbooks that are located in on the public Supermarket as well as private Chef Supermarket sites. A user account is required for any community actions that write data to the Chef Supermarket; however, the following arguments do not require a user account: download, search, install, and list.`,
+	Use:                   "supermarket COMMAND ARTIFACT_TYPE ARTIFACT_NAME",
+	Short:                 "chef supermarket subcommand is used to interact with cookbooks that are located in on the public Supermarket",
+	Long:                  `The chef supermarket subcommand is used to interact with cookbooks that are located in on the public Supermarket as well as private Chef Supermarket sites. A user account is required for any community actions that write data to the Chef Supermarket; however, the following arguments do not require a user account: download, search, install, and list.`,
+	DisableFlagsInUseLine: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
+		}
 		if len(args) > 0 && args[0] != "enable" {
 			info, _ := os.Stat(filepath.Join(os.TempDir(), "f816c88c-aa94-11ec-b909-0242ac120002"))
 			if info == nil {

--- a/cmd/supermarketDownload.go
+++ b/cmd/supermarketDownload.go
@@ -15,7 +15,7 @@ var (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketDownloadCmd = &cobra.Command{
-	Use:   "download <artifact-type>",
+	Use:   "download <artifact-type> <artifact-name>",
 	Short: "Use the download argument to download a cookbook from Chef Supermarket",
 	Long:  `A cookbook will be downloaded as a tar.gz archive and placed in the current working directory. If a cookbook (or cookbook version) has been deprecated and the --force option is not used, chef will alert the user that the cookbook is deprecated and then will provide the name of the most recent non-deprecated version of that cookbook.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketDownload.go
+++ b/cmd/supermarketDownload.go
@@ -15,7 +15,7 @@ var (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketDownloadCmd = &cobra.Command{
-	Use:   "download",
+	Use:   "download <artifact-type>",
 	Short: "Use the download argument to download a cookbook from Chef Supermarket",
 	Long:  `A cookbook will be downloaded as a tar.gz archive and placed in the current working directory. If a cookbook (or cookbook version) has been deprecated and the --force option is not used, chef will alert the user that the cookbook is deprecated and then will provide the name of the most recent non-deprecated version of that cookbook.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketInstall.go
+++ b/cmd/supermarketInstall.go
@@ -20,7 +20,7 @@ var (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketInstallCmd = &cobra.Command{
-	Use:   "install",
+	Use:   "install <artifact-type> <artifact-name>",
 	Short: "install command will install cookbook that has been downloaded from Chef Supermarket to a local git repository",
 	Long:  `install command will install cookbook that has been downloaded from Chef Supermarket to a local git repository. This action uses the git version control system in conjunction with Chef Supermarket site to install community-contributed cookbooks to the local chef-repo.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -40,8 +40,8 @@ var supermarketInstallCmd = &cobra.Command{
 		if len(cookBookPath) > 1 {
 			installPath = cookBookPath
 		} else {
-			path,err := core.GetDefaultCookbookPath()
-			if err != nil{
+			path, err := core.GetDefaultCookbookPath()
+			if err != nil {
 				ui.Fatal(err.Error())
 				os.Exit(1)
 			}

--- a/cmd/supermarketList.go
+++ b/cmd/supermarketList.go
@@ -16,7 +16,7 @@ var sortBy, withUri, user string
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list <artifact-type> <artifact-name>",
 	Short: "Use the list argument to view a list of cookbooks that are currently available at Chef Supermarket.",
 	Long:  `Use the list argument to view a list of cookbooks that are currently available at Chef Supermarket.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketSearch.go
+++ b/cmd/supermarketSearch.go
@@ -16,7 +16,7 @@ var query, format string
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketSearchCmd = &cobra.Command{
-	Use:   "search <artifact-type> <artifact-name>",
+	Use:   "search <artifact-type> <keyword>",
 	Short: "Search indexes allow queries to be made for any type of data that is indexed by the Chef Infra Server, including data bags (and data bag items), environments, nodes, and roles",
 	Long:  `Search indexes allow queries to be made for any type of data that is indexed by the Chef Infra Server, including data bags (and data bag items), environments, nodes, and roles. A defined query syntax is used to support search patterns like exact, wildcard, range, and fuzzy. A search is a full-text query that can be done from several locations, including from within a recipe, by using the search subcommand in chef.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketSearch.go
+++ b/cmd/supermarketSearch.go
@@ -16,7 +16,7 @@ var query, format string
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketSearchCmd = &cobra.Command{
-	Use:   "search",
+	Use:   "search <artifact-type> <artifact-name>",
 	Short: "Search indexes allow queries to be made for any type of data that is indexed by the Chef Infra Server, including data bags (and data bag items), environments, nodes, and roles",
 	Long:  `Search indexes allow queries to be made for any type of data that is indexed by the Chef Infra Server, including data bags (and data bag items), environments, nodes, and roles. A defined query syntax is used to support search patterns like exact, wildcard, range, and fuzzy. A search is a full-text query that can be done from several locations, including from within a recipe, by using the search subcommand in chef.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketShare.go
+++ b/cmd/supermarketShare.go
@@ -17,7 +17,7 @@ import (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketShareCmd = &cobra.Command{
-	Use:                "share",
+	Use:                "share <artifact-type> <artifact-name>",
 	Short:              "Use the share argument to add a cookbook to Chef Supermarket.",
 	Long:               `Use the share argument to add a cookbook to Chef Supermarket. This action will require a user account and a certificate for Chef Supermarket. By default, chef will use the user name and API key that is identified in the configuration file used during the upload; otherwise these values must be specified on the command line or in an alternate configuration file.`,
 	DisableFlagParsing: true,

--- a/cmd/supermarketShow.go
+++ b/cmd/supermarketShow.go
@@ -14,7 +14,7 @@ import (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketShowCmd = &cobra.Command{
-	Use:   "show",
+	Use:   "show <artifact-type> <artifact-name>",
 	Short: "Use the show argument to view information about a cookbook located at Chef Supermarket.\n\n",
 	Long:  ` Use the show argument to view information about a cookbook located at Chef Supermarket.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supermarketUnshare.go
+++ b/cmd/supermarketUnshare.go
@@ -16,7 +16,7 @@ import (
 
 // supermarketSearchCmd represents the supermarket search
 var supermarketUnShareCmd = &cobra.Command{
-	Use:   "unshare",
+	Use:   "unshare <artifact-type> <artifact-name>",
 	Short: "Use the unshare argument to stop the sharing of a cookbook located at Chef Supermarket.",
 	Long:  `Use the unshare argument to stop the sharing of a cookbook located at Chef Supermarket. Only the maintainer of a cookbook may perform this action.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -18,7 +18,7 @@ chef is a command-line tool that provides an interface between a local chef-repo
                         Searching of indexed data on the Chef Infra Server.
 
 Usage:
-  chef supermarket [command]
+  chef supermarket COMMAND ARTIFACT_TYPE ARTIFACT_NAME
 
 Available Commands:
   help        Help about any command


### PR DESCRIPTION
`chef supermarket` command usage help content specifies use of explicit artifact type i.e. `cookbook`.
It does not mention need of explicitly specifying artifact type after the subcommand prior to this change.
This change also displays help if no command argument is given.

Signed-off-by: Pranay Singh <i5singh.pranay@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
